### PR TITLE
ci: add iOS build/test and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Build & Test (iOS Simulator)
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Show toolchain
+        run: |
+          xcodebuild -version
+          swift --version
+
+      - name: Pick an available iPhone simulator
+        id: sim
+        run: |
+          UDID=$(xcrun simctl list devices available --json | python3 -c '
+          import json, sys
+          devices = json.load(sys.stdin)["devices"]
+          cands = [d for runtime in devices for d in devices[runtime]
+                   if d.get("isAvailable") and "iPhone" in d.get("name", "")]
+          print(cands[-1]["udid"] if cands else "")
+          ')
+          if [ -z "$UDID" ]; then
+            echo "::error::No available iPhone simulator found on the runner"
+            xcrun simctl list devices available
+            exit 1
+          fi
+          echo "udid=$UDID" >> "$GITHUB_OUTPUT"
+          echo "Selected simulator UDID: $UDID"
+
+      - name: Build & test
+        run: |
+          set -o pipefail
+          xcodebuild test \
+            -project sdk/CustomerPulseSDK/CustomerPulse.xcodeproj \
+            -scheme CustomerPulse \
+            -destination "platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}" \
+            CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+
+on:
+  push:
+    tags:
+      # Semver tags (matches the pod version scheme, e.g. 2.1.0 — no "v" prefix)
+      - '[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Lint, GitHub Release & Publish Pod
+    runs-on: macos-latest
+    env:
+      # Set this repo secret to enable automatic CocoaPods trunk publishing.
+      # Obtain it from ~/.netrc (the trunk.cocoapods.org password) after
+      # `pod trunk register`. If unset, the trunk push step is skipped.
+      COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Lint podspec
+        run: pod spec lint CustomerPulseSDK.podspec --allow-warnings
+
+      - name: Create GitHub release (draft)
+        if: ${{ success() }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          draft: true
+          prerelease: false
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to CocoaPods trunk
+        if: ${{ success() && env.COCOAPODS_TRUNK_TOKEN != '' }}
+        run: pod trunk push CustomerPulseSDK.podspec --allow-warnings
+
+      - name: Trunk publish skipped (no token)
+        if: ${{ env.COCOAPODS_TRUNK_TOKEN == '' }}
+        run: echo "COCOAPODS_TRUNK_TOKEN secret not set — skipping 'pod trunk push'. Publish manually or add the secret to automate it."


### PR DESCRIPTION
## Summary
iOS had no CI. This adds two GitHub Actions workflows, bringing it to parity with the Android repo (and adding the build/test gate Android already gets locally).

### `ci.yml` — build & test
- Triggers on push/PR to `main` + manual dispatch.
- Runs `xcodebuild test` against the shared `CustomerPulse` scheme on a dynamically-selected available iPhone simulator (avoids the brittle hardcoded `name=iPhone 15 Pro,OS=latest` destination).

### `release.yml` — lint + release + publish
- Triggers on semver tags (`[0-9]+.[0-9]+.[0-9]+`, matching the pod version scheme — no `v` prefix).
- `pod spec lint`, then a draft GitHub release, then `pod trunk push` **only if** the `COCOAPODS_TRUNK_TOKEN` repo secret is set (otherwise skipped with a notice). Merging this changes nothing until you opt in by adding the secret.

Refs TD-001. This PR run exercises `ci.yml` itself.